### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest tests/ --ignore=tests/test_integration.py --ignore=tests/test_admin_integration.py -v


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to run unit tests on push/PR to main
- Tests run across Python 3.10, 3.11, 3.12, and 3.13
- Integration tests are excluded

## Test plan
- [x] Verify CI passes on this PR