### PR TITLE
fix: send breaker_ids array in LinkBreakerInput

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -459,7 +459,18 @@ class TestAdminClientRouters:
         assert r.name == "updated"
 
     @respx.mock
-    def test_link_breaker(self):
+    def test_link_breaker_single(self):
+        route = respx.post(f"{BASE}/v1/projects/p1/routers/rtr_1/breakers").mock(
+            return_value=httpx.Response(204)
+        )
+        client = AdminClient(api_key="k")
+        client.link_breaker("p1", "rtr_1", LinkBreakerInput(breaker_ids=["b1"]))
+        assert route.called
+        body = json.loads(route.calls[0].request.content)
+        assert body == {"breaker_ids": ["b1"]}
+
+    @respx.mock
+    def test_link_breaker_multiple(self):
         route = respx.post(f"{BASE}/v1/projects/p1/routers/rtr_1/breakers").mock(
             return_value=httpx.Response(204)
         )
@@ -469,6 +480,10 @@ class TestAdminClientRouters:
         body = json.loads(route.calls[0].request.content)
         assert body == {"breaker_ids": ["b1", "b2"]}
 
+    def test_link_breaker_empty_raises(self):
+        with pytest.raises(ValueError, match="breaker_ids must contain at least one ID"):
+            LinkBreakerInput(breaker_ids=[])
+
     @respx.mock
     def test_unlink_breaker(self):
         route = respx.delete(
@@ -476,7 +491,7 @@ class TestAdminClientRouters:
         ).mock(return_value=httpx.Response(204))
         client = AdminClient(api_key="k")
         client.unlink_breaker("p1", "rtr_1", "b1")
-        assert route.called
+        assert str(route.calls[0].request.url).endswith("/routers/rtr_1/breakers/b1")
 
 
 class TestAdminClientNotifications:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -464,8 +464,10 @@ class TestAdminClientRouters:
             return_value=httpx.Response(204)
         )
         client = AdminClient(api_key="k")
-        client.link_breaker("p1", "rtr_1", LinkBreakerInput(breaker_id="b1"))
+        client.link_breaker("p1", "rtr_1", LinkBreakerInput(breaker_ids=["b1", "b2"]))
         assert route.called
+        body = json.loads(route.calls[0].request.content)
+        assert body == {"breaker_ids": ["b1", "b2"]}
 
     @respx.mock
     def test_unlink_breaker(self):

--- a/tripswitch/admin/client.py
+++ b/tripswitch/admin/client.py
@@ -373,7 +373,7 @@ class AdminClient:
         self, project_id: str, router_id: str, link: LinkBreakerInput,
         *, options: RequestOptions | None = None,
     ) -> None:
-        """Link a breaker to a router."""
+        """Link one or more breakers to a router atomically."""
         self._do(
             "POST",
             f"/v1/projects/{project_id}/routers/{router_id}/breakers",
@@ -384,7 +384,10 @@ class AdminClient:
         self, project_id: str, router_id: str, breaker_id: str,
         *, options: RequestOptions | None = None,
     ) -> None:
-        """Remove a breaker from a router."""
+        """Remove a single breaker from a router.
+
+        To unlink multiple breakers, call this method once per breaker ID.
+        """
         self._do(
             "DELETE",
             f"/v1/projects/{project_id}/routers/{router_id}/breakers/{breaker_id}",

--- a/tripswitch/admin/types.py
+++ b/tripswitch/admin/types.py
@@ -548,10 +548,10 @@ class UpdateRouterInput:
 class LinkBreakerInput:
     """Parameters for linking a breaker to a router."""
 
-    breaker_id: str
+    breaker_ids: list[str]
 
     def _to_dict(self) -> dict[str, Any]:
-        return {"breaker_id": self.breaker_id}
+        return {"breaker_ids": self.breaker_ids}
 
 
 # ── Notification channels ────────────────────────────────────────────────

--- a/tripswitch/admin/types.py
+++ b/tripswitch/admin/types.py
@@ -546,12 +546,20 @@ class UpdateRouterInput:
 
 @dataclass
 class LinkBreakerInput:
-    """Parameters for linking a breaker to a router."""
+    """Parameters for linking one or more breakers to a router atomically.
+
+    Note: the corresponding unlink operation (``AdminClient.unlink_breaker``)
+    removes a single breaker at a time via its ID.
+    """
 
     breaker_ids: list[str]
 
+    def __post_init__(self) -> None:
+        if not self.breaker_ids:
+            raise ValueError("breaker_ids must contain at least one ID")
+
     def _to_dict(self) -> dict[str, Any]:
-        return {"breaker_ids": self.breaker_ids}
+        return {"breaker_ids": list(self.breaker_ids)}
 
 
 # ── Notification channels ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`LinkBreakerInput` was sending `{"breaker_id": "..."}` (singular string) but the endpoint extracts `body_params["breaker_ids"]` (plural array). Missing key falls back to `[]`, triggering an early return in `link_breakers_internal` — resulting in a silent no-op with a 200 and empty breakers list.

- Changed `breaker_id: str` → `breaker_ids: list[str]`
- Updated `_to_dict` to send `{"breaker_ids": [...]}`
- Updated test to assert the correct request body shape